### PR TITLE
Remove setup_version as not required

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -6,7 +6,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="JomaShop_NewRelicMonitoring" setup_version="1.0.0">
+    <module name="JomaShop_NewRelicMonitoring">
         <sequence>
             <module name="Magento_NewRelicReporting" />
             <module name="Magento_GraphQl" />


### PR DESCRIPTION
Remove setup_version as not required anymore for Magento modules, its even take some additional resources of Magento when version is set