### PR TITLE
Update for version2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## v2.0.0
+* Improved error extraction for `LocalizedException` and `AggregateExceptionInterface`
+* Support for using `newrelic_add_custom_parameter` instead of `newrelic_notice_error`.
+    * This requires custom code providing a `ReportErrorEvaluatorInterface` which controls which errors are diverted
+* Support for reading the `x-client-version` header to set ClientVersion
+* Magento 2.4.4's NewRelic logging is disabled to prevent double work extracting the data
+* If the GQL's AST is available, as in 2.4.7, the extracted data changes and should be improved.
+* Transaction naming uses forward slashes only
+    * This will 'break' all dashboards and queries that check or facet on the operation name
+
+## v1.1.1
+* Send requested fields as a custom parameter to NR
+
+## v1.1.0
+* Able to log GraphQl errors

--- a/Helper/NewRelicReportData.php
+++ b/Helper/NewRelicReportData.php
@@ -10,9 +10,9 @@ use GraphQL\Type\Definition\ObjectType;
 
 class NewRelicReportData
 {
-    const PREFIX = '/GraphQl/Controller/GraphQl\\';
-    const BACKSLASH = '\\';
-    const MULTIPLE_QUERIES_FLAG = 'Multiple';
+    private const PREFIX = '/GraphQl/Controller/GraphQl';
+    private const SEPARATOR = '/';
+    private const MULTIPLE_QUERIES_FLAG = 'Multiple';
 
     /**
      * Get transaction data from GraphQl schema
@@ -63,7 +63,7 @@ class NewRelicReportData
 
     /**
      * @param $schema
-     * @return \GraphQL\Type\Definition\ObjectType
+     * @return ObjectType
      */
     private function getGqlFieldsInfo($schema)
     {
@@ -83,14 +83,14 @@ class NewRelicReportData
 
     /**
      * Build a transaction name based on query type and operation name
-     * format: /GraphQl/Controller/GraphQl\{operation name|(query|mutation)}\{name|Multiple}
+     * format: /GraphQl/Controller/GraphQl/{operation name|(query|mutation)}/{name|Multiple}
      * @param $gqlCallType
      * @param string $operationName
      * @return string
      */
     private function buildTransactionName($gqlCallType, $operationName)
     {
-        return self::PREFIX . $gqlCallType . self::BACKSLASH . $operationName;
+        return self::PREFIX . self::SEPARATOR . $gqlCallType . self::SEPARATOR . $operationName;
     }
 
     /**

--- a/Helper/NewRelicReportData.php
+++ b/Helper/NewRelicReportData.php
@@ -5,6 +5,11 @@
 
 namespace JomaShop\NewRelicMonitoring\Helper;
 
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\Visitor;
 use Magento\Framework\GraphQl\Schema;
 use GraphQL\Type\Definition\ObjectType;
 
@@ -17,10 +22,10 @@ class NewRelicReportData
     /**
      * Get transaction data from GraphQl schema
      * @param Schema $schema
-     * @param $querySource
+     * @param DocumentNode|string $querySource
      * @return array
      */
-    public function getTransactionData(Schema $schema, $querySource)
+    public function getTransactionData(Schema $schema, DocumentNode|string $querySource)
     {
         // Check Schema
         $gqlFieldsInfo = $this->getGqlFieldsInfo($schema);
@@ -28,21 +33,48 @@ class NewRelicReportData
             return [];
         }
 
-        // Extract Data
-        $gqlInfo = $this->extractGqlInfo($gqlFieldsInfo);
-        $operationName = $this->getOperationNameFromQueryString($querySource);
+        if (is_string($querySource)) {
+            // Extract from source as string
+            // - The results here are not equivilent to as from DocumentNode
+            // - (transactionName should be the same or similar in most cases)
+            $gqlInfo = $this->extractGqlInfo($gqlFieldsInfo);
+            return [
+                'transactionName' => $this->buildTransactionName(
+                    $gqlInfo['gql_call_type'],
+                    $this->buildGqlCallName(
+                        $this->getOperationNameFromQueryString($querySource),
+                        $gqlInfo['all_field_names'],
+                        $gqlInfo['last_field_name']
+                    )
+                ),
+                'fieldCount' => $gqlInfo['field_count'],
+                'fieldNames' => $gqlInfo['all_field_names'],
+            ];
+        }
 
-        // Determine Final Call Name
-        $finalGqlCallName = empty($operationName)
-            ? ($gqlInfo['field_count'] > 1 ? self::MULTIPLE_QUERIES_FLAG : $gqlInfo['first_field_name'])
-            : $operationName;
-
-        // Format and Return
+        $gqlInfo = $this->extractGqlInfoFromAst($querySource);
         return [
-            'transactionName' => $this->buildTransactionName($gqlInfo['gql_call_type'], $finalGqlCallName),
+            'transactionName' => $this->buildTransactionName(
+                $gqlInfo['operation_type'],
+                $this->buildGqlCallName(
+                    $gqlInfo['operation_name'],
+                    $gqlInfo['operation_field_names'],
+                    $gqlInfo['operation_first_field_alias_or_name'],
+                )
+            ),
             'fieldCount' => $gqlInfo['field_count'],
-            'fieldNames' => $gqlInfo['all_field_names'],
+            'fieldNames' => $gqlInfo['operation_field_names'],
         ];
+
+    }
+
+    private function buildGqlCallName($operationName, $fieldsUsed, $firstFieldName)
+    {
+        return $operationName ?: (
+            count($fieldsUsed) > 1
+                ? self::MULTIPLE_QUERIES_FLAG
+                : $firstFieldName
+            );
     }
 
     /**
@@ -52,11 +84,10 @@ class NewRelicReportData
     private function extractGqlInfo(ObjectType $gqlFieldsInfo)
     {
         $gqlFields = $gqlFieldsInfo->getFields();
-
         return [
             'field_count' => count($gqlFields),
             'gql_call_type' => $gqlFieldsInfo->name,
-            'first_field_name' =>  array_key_first($gqlFields),
+            'last_field_name' =>  array_key_last($gqlFields),
             'all_field_names' => array_keys($gqlFields),
         ];
     }
@@ -88,17 +119,87 @@ class NewRelicReportData
      * @param string $operationName
      * @return string
      */
-    private function buildTransactionName($gqlCallType, $operationName)
+    private function buildTransactionName($gqlCallType, $operationName): string
     {
         return self::PREFIX . self::SEPARATOR . $gqlCallType . self::SEPARATOR . $operationName;
     }
 
     /**
+     * Extracts some relevant data from a DocumentNode
+     *
+     * @param DocumentNode $ast
+     * @return array
+     * @throws \Exception
+     */
+    public function extractGqlInfoFromAst(DocumentNode $ast)
+    {
+        $firstOperationName = null;
+        $operationType = null;
+        $operationTypeOperationName = null;
+        $fieldNodeNames = [];
+        $allOperationTopLevelFields = [];
+        Visitor::visit($ast, [
+            NodeKind::FIELD =>
+                function (FieldNode $fieldNode) use (&$fieldNodeNames) {
+                    $fieldNodeNames[] = $fieldNode->name->value ?? null;
+                    return $fieldNode->selectionSet ? null : Visitor::skipNode();
+                },
+            NodeKind::OPERATION_DEFINITION =>
+                function (OperationDefinitionNode $operationDefinitionNode) use (
+                    &$operationType,
+                    &$operationTypeOperationName,
+                    &$allOperationTopLevelFields,
+                    &$firstOperationName,
+                ) {
+                    // Gather all operation 'operation' names
+                    $operationFields = $operationDefinitionNode
+                        ->selectionSet
+                        ->selections;
+                    foreach ($operationFields as $operationField) {
+                        /** @var FieldNode $operationField */
+                        $allOperationTopLevelFields[] = $operationField->name->value;
+                    }
+
+                    // Set the first operation name
+                    // Priorities Mutations
+                    if ($operationType !== null) {
+                        if ($operationDefinitionNode->operation !== 'mutation') {
+                            // We have a value and not a mutation (Skip)
+                            return;
+                        }
+
+                        if ($operationType === 'mutation') {
+                            // Keep the first mutation found (Skip)
+                            return;
+                        }
+                    }
+
+                    // Set first operation or override the non-mutation
+                    $operationType = $operationDefinitionNode->operation;
+                    $firstOperationName = $operationDefinitionNode->name->value ?? '';
+
+                    /** @var FieldNode $firstField */
+                    $firstField = $operationFields[0];
+                    $operationTypeOperationName = $firstField->alias->value ?? $firstField->name->value;
+                },
+        ]);
+
+        $filteredFieldNames = array_filter($fieldNodeNames, fn($name) => $name && $name !== '__typename');
+        return [
+            'operation_type' => ucfirst($operationType),
+            'operation_name' => $firstOperationName,
+            'operation_field_names' => $allOperationTopLevelFields,
+            'operation_first_field_alias_or_name' => $operationTypeOperationName,
+            'field_count' => count($filteredFieldNames),
+        ];
+    }
+
+    /**
      * Get operation name from query
-     * @param $query
+     * @param string $query
      * @return string
      */
-    public function getOperationNameFromQueryString($query)
+    public function getOperationNameFromQueryString(string $query)
     {
         // Get the string before query input, which is indicated by a '{'
         $operationBeginningSegment = substr($query, 0, stripos($query, '{'));

--- a/Model/ErrorReporter/ReportErrorEvaluatorInterface.php
+++ b/Model/ErrorReporter/ReportErrorEvaluatorInterface.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Jomashop
+ */
+
+namespace JomaShop\NewRelicMonitoring\Model\ErrorReporter;
+
+use Throwable;
+
+interface ReportErrorEvaluatorInterface
+{
+    public function evaluateError(Throwable $error): ReportErrorEvaluatorOutput;
+}

--- a/Model/ErrorReporter/ReportErrorEvaluatorOutput.php
+++ b/Model/ErrorReporter/ReportErrorEvaluatorOutput.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @author Jomashop
+ */
+
+namespace JomaShop\NewRelicMonitoring\Model\ErrorReporter;
+
+class ReportErrorEvaluatorOutput
+{
+    public function __construct(
+        private readonly bool $isReportAsCustomParameter,
+        private readonly ?array $extraData
+    ) {
+    }
+
+    public function getIsReportAsCustomParameter(): bool
+    {
+        return $this->isReportAsCustomParameter;
+    }
+
+    public function getExtraData(): array
+    {
+        return $this->extraData ?? [];
+    }
+}

--- a/Model/NullLogger/NullGetLogData.php
+++ b/Model/NullLogger/NullGetLogData.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Jomashop
+ */
+
+namespace JomaShop\NewRelicMonitoring\Model\NullLogger;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\Http as HttpResponse;
+use Magento\Framework\GraphQl\Schema;
+use Magento\GraphQl\Helper\Query\Logger\LogData;
+
+/**
+ * Class NullGetLogData
+ */
+class NullGetLogData extends LogData
+{
+    public function getLogData(
+        RequestInterface $request,
+        array $data,
+        ?Schema $schema,
+        ?HttpResponse $response
+    ): array
+    {
+        return [];
+    }
+}

--- a/Model/NullLogger/NullNewRelicLogger.php
+++ b/Model/NullLogger/NullNewRelicLogger.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @author Jomashop
+ */
+
+namespace JomaShop\NewRelicMonitoring\Model\NullLogger;
+
+use Magento\GraphQl\Model\Query\Logger\LoggerInterface;
+
+/**
+ * Class NullNewRelicLogger
+ */
+class NullNewRelicLogger implements LoggerInterface
+{
+
+    public function execute(array $queryDetails)
+    {
+        // Do nothing
+    }
+}

--- a/Plugin/ErrorHandler.php
+++ b/Plugin/ErrorHandler.php
@@ -4,36 +4,62 @@
  */
 namespace JomaShop\NewRelicMonitoring\Plugin;
 
+use Magento\Framework\Exception\AggregateExceptionInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Query\ErrorHandler as QueryErrorHandler;
 use Magento\NewRelicReporting\Model\NewRelicWrapper;
+use Throwable;
 
 class ErrorHandler
 {
-    /**
-     * @var NewRelicWrapper
-     */
-    private $newRelicWrapper;
-
-    /**
-     * @param NewRelicWrapper $newRelicWrapper
-     */
     public function __construct(
-        NewRelicWrapper $newRelicWrapper
+        private readonly NewRelicWrapper $newRelicWrapper,
     ) {
-        $this->newRelicWrapper = $newRelicWrapper;
     }
 
     public function beforeHandle(QueryErrorHandler $errorHandler, array $errors, callable $formatter)
     {
-        if (empty($errors)) {
+        // We want to find the first error that has a previous
+        // - errors are expected to be wrapped by graphql
+        $firstPreviousError = array_filter(
+            array_map(
+                fn($error) => $error->getPrevious(),
+                $errors
+            ),
+        )[0] ?? null;
+        if (!$firstPreviousError) {
             return;
         }
 
-        foreach ($errors as $error) {
-            $previousError = $error->getPrevious();
-            if ($previousError instanceof \Exception) {
-                $this->newRelicWrapper->reportError($previousError);
-            }
+        // Get error data
+        $errorData = $this->getErrorData($firstPreviousError);
+
+        // Report data
+        $this->newRelicWrapper->reportError($errorData['errorToReport']);
+        foreach ($errorData['extraData'] as $key => $value) {
+            $this->newRelicWrapper->addCustomParameter($key, $value);
         }
+    }
+
+    private function getErrorData(Throwable $error): array
+    {
+        // Get inner exception if available
+        // - See eg: \Magento\QuoteGraphQl\Model\Cart\AddSimpleProductToCart::execute
+        $firstInnerError = $error instanceof AggregateExceptionInterface
+            ? $error->getErrors()[0] ?? null
+            : null;
+
+        // Prepare data
+        $data = [
+            'errorToReport' => $firstInnerError ?? $error,
+            'extraData' => []
+        ];
+
+        // Add Aggregate exception message (As we are using the first inner error to report)
+        if ($firstInnerError instanceof AggregateExceptionInterface) {
+            $data['extraData']['ExceptionAggregateMessage'] = $firstInnerError->getMessage();
+        }
+
+        return $data;
     }
 }

--- a/Plugin/ErrorHandler.php
+++ b/Plugin/ErrorHandler.php
@@ -4,6 +4,7 @@
  */
 namespace JomaShop\NewRelicMonitoring\Plugin;
 
+use JomaShop\NewRelicMonitoring\Model\ErrorReporter\ReportErrorEvaluatorInterface;
 use Magento\Framework\Exception\AggregateExceptionInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Query\ErrorHandler as QueryErrorHandler;
@@ -14,6 +15,7 @@ class ErrorHandler
 {
     public function __construct(
         private readonly NewRelicWrapper $newRelicWrapper,
+        private readonly ?ReportErrorEvaluatorInterface $reportErrorEvaluator = null,
     ) {
     }
 
@@ -35,7 +37,7 @@ class ErrorHandler
         $errorData = $this->getErrorData($firstPreviousError);
 
         // Report data
-        $this->newRelicWrapper->reportError($errorData['errorToReport']);
+        $this->reportErrorOrAsCustomParameters($errorData['errorToReport']);
         foreach ($errorData['extraData'] as $key => $value) {
             $this->newRelicWrapper->addCustomParameter($key, $value);
         }
@@ -66,5 +68,99 @@ class ErrorHandler
         }
 
         return $data;
+    }
+
+    private function reportErrorOrAsCustomParameters(Throwable $errorToReport): void
+    {
+        if (!$this->reportErrorEvaluator) {
+            // Default to report as Error
+            $this->newRelicWrapper->reportError($errorToReport);
+            return;
+        }
+
+        $evaluationResult = $this->reportErrorEvaluator->evaluateError($errorToReport);
+        if (!$evaluationResult->getIsReportAsCustomParameter()) {
+            $this->newRelicWrapper->reportError($errorToReport);
+            return;
+        }
+
+        // We want to send this as a custom event
+        $this->newRelicWrapper->addCustomParameter('ExceptionIsSkipReportError', true);
+        $this->newRelicWrapper->addCustomParameter('ExceptionClass', get_class($errorToReport));
+        $this->newRelicWrapper->addCustomParameter('ExceptionMessage', $errorToReport->getMessage());
+
+        // - Add headers (As this is not an error event)
+        $this->maybeAddRequestHeadersForReportAsCustomParameter();
+
+        // - Add extra data
+        foreach ($evaluationResult->getExtraData() as $key => $value) {
+            $this->newRelicWrapper->addCustomParameter($key, $value);
+        }
+    }
+
+    private function maybeAddRequestHeadersForReportAsCustomParameter(): void
+    {
+        // We only want referer for now
+        $newRelicFieldNameForHeader = 'request.headers.referer';
+        $phpServerHeaderName = 'HTTP_REFERER';
+
+        // Note: we are using server directly as NewRelic core code (likely) does not use Magento special logic
+        $serverValue = $_SERVER[$phpServerHeaderName] ?? null;
+        if (!$serverValue) {
+            // No value, nothing to do
+            return;
+        }
+
+        // This is the logic as described in attribute docs
+        // (See: https://docs.newrelic.com/docs/apm/agents/php-agent/attributes/enable-or-disable-attributes/)
+        // - Root level takes precedence for enabled.
+        // - Destination enabled takes precedence over include and exclude.
+        // - Attribute is included if the destination is enabled.
+        // - Exclude always supersedes include.
+        // - Keys are case sensitive.
+        // - Use a star (\*) for wildcards.
+        // - Most specific setting for a key takes priority.
+        // - Include or exclude affects the specific destination.
+        // Notes: This code is running a simplified version of the logic linked above
+        // - ignoring wildcard logic
+        // - ignoring prefix logic
+
+        // No need to check this as if false all custom params are removed
+        // |if (ini_get('newrelic.attributes.enabled') === 'false') {
+        // |   return;
+        // |}
+
+        if (ini_get('newrelic.error_collector.attributes.enabled') === '0') {
+            // If not enabled for error_collector it would not exist there (So don't add here)
+            return;
+        }
+
+        // No need to check this as if in list will exclude the custom param
+        // |if (str_contains(ini_get('newrelic.attributes.exclude'), $headerName)) {
+        // |    return;
+        // |}
+
+        if (str_contains(ini_get('newrelic.attributes.include'), $newRelicFieldNameForHeader)) {
+            // It will be included via normal include logic
+            return;
+        }
+
+        // No need to check this as if false all matching params are removed
+        // |if (str_contains(ini_get('newrelic.transaction_events.attributes.exclude'), $headerName)) {
+        // |   return;
+        // |}
+
+        if (str_contains(ini_get('newrelic.transaction_events.attributes.include'), $newRelicFieldNameForHeader)) {
+            // It will be included via normal include logic
+            return;
+        }
+
+        if (str_contains(ini_get('newrelic.error_collector.attributes.exclude'), $newRelicFieldNameForHeader)) {
+            // If not enabled for error_collector it would not exist there (So don't add here)
+            return;
+        }
+
+        // Add value
+        $this->newRelicWrapper->addCustomParameter($newRelicFieldNameForHeader, $serverValue);
     }
 }

--- a/Plugin/ErrorHandler.php
+++ b/Plugin/ErrorHandler.php
@@ -60,6 +60,11 @@ class ErrorHandler
             $data['extraData']['ExceptionAggregateMessage'] = $firstInnerError->getMessage();
         }
 
+        // Add raw message from LocalizedException (With placeholders)
+        if ($data['errorToReport'] instanceof LocalizedException) {
+            $data['extraData']['ExceptionRawMessage'] = $data['errorToReport']->getRawMessage();
+        }
+
         return $data;
     }
 }

--- a/Plugin/NewRelicClientVersion.php
+++ b/Plugin/NewRelicClientVersion.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JomaShop\NewRelicMonitoring\Plugin;
+
+use Magento\GraphQl\Controller\GraphQl;
+use Magento\Framework\App\RequestInterface;
+use Magento\NewRelicReporting\Model\NewRelicWrapper;
+
+class NewRelicClientVersion
+{
+    const CLIENT_VERSION_HEADER = 'x-client-version';
+
+    /**
+     * @param NewRelicWrapper $newRelicWrapper
+     */
+    public function __construct(
+        private NewRelicWrapper $newRelicWrapper,
+    ) {
+    }
+
+    public function beforeDispatch(
+        GraphQl $subject,
+        RequestInterface $request,
+    ) {
+        $clientVersion = $request->getHeader(self::CLIENT_VERSION_HEADER);
+        $this->newRelicWrapper->addCustomParameter('ClientVersion', $clientVersion ?? 'N/A');
+    }
+}

--- a/Plugin/NewRelicMonitoring.php
+++ b/Plugin/NewRelicMonitoring.php
@@ -5,6 +5,7 @@
 
 namespace JomaShop\NewRelicMonitoring\Plugin;
 
+use GraphQL\Language\AST\DocumentNode;
 use Magento\Framework\GraphQl\Query\QueryProcessor;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Schema;
@@ -46,7 +47,7 @@ class NewRelicMonitoring
     public function beforeProcess(
         QueryProcessor $subject,
         Schema $schema,
-        string $source,
+        DocumentNode|string $source,
         ContextInterface $contextValue = null,
         array $variableValues = null,
         string $operationName = null

--- a/Plugin/NewRelicMonitoring.php
+++ b/Plugin/NewRelicMonitoring.php
@@ -51,6 +51,11 @@ class NewRelicMonitoring
         array $variableValues = null,
         string $operationName = null
     ) {
+        if (!$this->newRelicWrapper->isExtensionInstalled()) {
+            // No need to extract the data
+            return;
+        }
+
         $transactionData = $this->dataHelper->getTransactionData($schema, $source);
         if (empty($transactionData)) {
             return;

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mutation createCustomerTest{
   }
 }
 ```
-In New Relic, the transaction name would be: `/GraphQl/Controller/GraphQl\Mutation\createCustomerTest`
+In New Relic, the transaction name would be: `/GraphQl/Controller/GraphQl/Mutation/createCustomerTest`
 
 2. Operation name is not set and only 1 query/mutation is requested
 ```graphql
@@ -61,7 +61,7 @@ mutation {
 }
 ```
 
-In NR, the transaction name would be `/GraphQl/Controller/GraphQl\Mutation\createCustomer`
+In NR, the transaction name would be `/GraphQl/Controller/GraphQl/Mutation/createCustomer`
 
 3. Operation name is not set and multiple queries/mutations are requested
 ```graphql
@@ -95,8 +95,24 @@ query {
 }
 ```
 
-In NR, the transaction name would be `/GraphQl/Controller/GraphQl\Query\Multiple`
+In NR, the transaction name would be `/GraphQl/Controller/GraphQl/Query/Multiple`
 
-## Change Log
-- v1.1.1: Send requested fields as a custom parameter to NR
-- v1.1.0: Able to log GraphQl errors
+---
+### Other features
+This module also supports using `newrelic_add_custom_parameter` instead of `newrelic_notice_error`.
+- See ErrorHandler and ReportErrorEvaluatorInterface
+- This can be used to reduce the number of `GraphQlInputException` / `GraphQlAuthorizationException` / `GraphQlAuthenticationException` which are logged as errors
+- Data is set to ExceptionIsSkipReportError / ExceptionClass / ExceptionMessage
+
+Error extraction:
+- If the error is an `AggregateExceptionInterface` the module tries to use the inner error.
+- If the error is a `LocalizedException` then ExceptionRawMessage is set as a custom parameter
+
+If the header `x-client-version` is set then ClientVersion is set as a custom parameter
+- This can be used to track the Frontend Version sending the GQL request
+
+Core Magento logging from 2.4.4 is disabled as running both is does not provide extra value
+
+If Magento >= 2.4.7 is used the extracted data changes
+- The AST is parsed to extract various data
+- <2.4.7 parses the string

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "jomashop/module-new-relic-monitoring-for-gql",
   "description": "Send GraphQL transactions to New Relic",
   "type": "magento2-module",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "require": {
     "magento/framework": "*"
   },

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,4 +9,22 @@
     <type name="Magento\Framework\GraphQl\Query\ErrorHandler">
         <plugin name="send_exception_trace_to_newrelic" type="JomaShop\NewRelicMonitoring\Plugin\ErrorHandler"/>
     </type>
+
+    <!-- Disable 2.4.4 GQL logging; we could look into adding a preference -->
+    <!-- Use Null Logger -->
+    <!-- Use null 'getData' to avoid the extra work -->
+    <preference
+            for="Magento\GraphQl\Model\Query\Logger\LoggerInterface"
+            type="JomaShop\NewRelicMonitoring\Model\NullLogger\NullNewRelicLogger"/>
+    <type name="Magento\GraphQl\Model\Query\Logger\LoggerPool">
+        <arguments>
+            <argument name="loggers" xsi:type="array">
+                <item name="newRelic" xsi:type="object">JomaShop\NewRelicMonitoring\Model\NullLogger\NullNewRelicLogger</item>
+            </argument>
+        </arguments>
+    </type>
+    <preference
+            for="Magento\GraphQl\Helper\Query\Logger\LogData"
+            type="JomaShop\NewRelicMonitoring\Model\NullLogger\NullGetLogData"/>
+    <!-- End -->
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3,6 +3,9 @@
     <type name="Magento\Framework\GraphQl\Query\QueryProcessor">
         <plugin name="newRelicNameTransaction" sortOrder="10" type="JomaShop\NewRelicMonitoring\Plugin\NewRelicMonitoring"/>
     </type>
+    <type name="Magento\GraphQl\Controller\GraphQl">
+        <plugin name="new_relic_client_version" sortOrder="10" type="JomaShop\NewRelicMonitoring\Plugin\NewRelicClientVersion"/>
+    </type>
     <type name="Magento\Framework\GraphQl\Query\ErrorHandler">
         <plugin name="send_exception_trace_to_newrelic" type="JomaShop\NewRelicMonitoring\Plugin\ErrorHandler"/>
     </type>


### PR DESCRIPTION
From Changelog

---
# Change Log

## v2.0.0
* Improved error extraction for `LocalizedException` and `AggregateExceptionInterface`
* Support for using `newrelic_add_custom_parameter` instead of `newrelic_notice_error`.
    * This requires custom code providing a `ReportErrorEvaluatorInterface` which controls which errors are diverted
* Support for reading the `x-client-version` header to set ClientVersion
* Magento 2.4.4's NewRelic logging is disabled to prevent double work extracting the data
* If the GQL's AST is available, as in 2.4.7, the extracted data changes and should be improved.
* Transaction naming uses forward slashes only
    * This will 'break' all dashboards and queries that check or facet on the operation name